### PR TITLE
Add the ability to create a stand-alone .phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /vendor/
 .idea/*
 composer.lock
-
+application.phar
 .idea/codeStyleSettings.xml
 
 .twgit_features_subject

--- a/application
+++ b/application
@@ -1,31 +1,4 @@
 #!/usr/bin/env php
 <?php
 
-/*
-|--------------------------------------------------------------------------
-| Register The Auto Loader
-|--------------------------------------------------------------------------
-|
-| Composer provides a convenient, automatically generated class loader
-| for our application. We just need to utilize it! We'll require it
-| into the script here so that we do not have to worry about the
-| loading of any our classes "manually". Feels great to relax.
-|
-*/
-
-require __DIR__ . '/bootstrap/autoload.php';
-
-$app = require_once __DIR__ . '/bootstrap/app.php';
-
-/*
-|--------------------------------------------------------------------------
-| Run The Artisan Application
-|--------------------------------------------------------------------------
-|
-| When we run the console application, the current CLI command will be
-| executed in this console and the response sent back to a terminal
-| or another output device for the developers. Here goes nothing!
-|
-*/
-
-$app->run();
+require_once __DIR__ . '/start.php';

--- a/build-phar.php
+++ b/build-phar.php
@@ -1,0 +1,15 @@
+<?php
+
+ini_set('phar.readonly', 0);
+
+$phar_file_name = 'application.phar';
+$included_paths = ['app/', 'vendor/', 'bootstrap/', 'start.php'];
+
+$phar = new Phar(__DIR__ . '/' . $phar_file_name,
+    FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::KEY_AS_FILENAME,
+    $phar_file_name
+);
+$phar->buildFromDirectory(dirname(__FILE__), '#' . implode('|', $included_paths) . '#');
+$phar->setStub($phar->createDefaultStub('start.php'));
+
+echo "\nSuccessfully compiled standalone application: " . realpath(__DIR__ . '/' . $phar_file_name) . "\n";

--- a/start.php
+++ b/start.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Register The Auto Loader
+|--------------------------------------------------------------------------
+|
+| Composer provides a convenient, automatically generated class loader
+| for our application. We just need to utilize it! We'll require it
+| into the script here so that we do not have to worry about the
+| loading of any our classes "manually". Feels great to relax.
+|
+*/
+
+require __DIR__ . '/bootstrap/autoload.php';
+
+$app = require_once __DIR__ . '/bootstrap/app.php';
+
+/*
+|--------------------------------------------------------------------------
+| Run The Artisan Application
+|--------------------------------------------------------------------------
+|
+| When we run the console application, the current CLI command will be
+| executed in this console and the response sent back to a terminal
+| or another output device for the developers. Here goes nothing!
+|
+*/
+
+$app->run();


### PR DESCRIPTION
Just a first draft to enable the creation of standalone .phar packages of the commands created by the developer.

If you're interested in such a feature, I can add the associated doc, etc. Also tell me if you want me to change the code style or anything :)

Usage:
php build-phar.php
php application.phar

The application.phar can then be used from anywhere and can be used as a distribution mean (no composer dependency).

Also, sorry, I had to move the php code from the "application" file because of the hashbang, because it's not compatible with windows.